### PR TITLE
Replace deprecated SmallTopAppBar

### DIFF
--- a/app/src/main/java/com/iplacex/medidores_app/ui/vm/FormScreen.kt
+++ b/app/src/main/java/com/iplacex/medidores_app/ui/vm/FormScreen.kt
@@ -21,7 +21,7 @@ fun FormScreen(
     onCancel: () -> Unit
 ) {
     Scaffold(
-        topBar = { SmallTopAppBar(title = { Text("Nueva lectura") }) }
+        topBar = { TopAppBar(title = { Text("Nueva lectura") }) }
     ) { inner ->
         Column(
             Modifier.padding(inner).padding(16.dp),


### PR DESCRIPTION
## Summary
- replace SmallTopAppBar with the stable TopAppBar in the form screen to match the available Material3 API

## Testing
- ./gradlew lint *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf5e30d1288322beba50f356ba1a62