### PR TITLE
Refactor: Update UI components and ViewModel logic

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/iplacex/medidores_app/ui/Nav.kt
+++ b/app/src/main/java/com/iplacex/medidores_app/ui/Nav.kt
@@ -1,5 +1,7 @@
 package com.iplacex.medidores_app.ui
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
@@ -15,6 +17,7 @@ private object Routes {
     const val FORM = "form"
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun AppNav(navController: NavHostController = rememberNavController()) {
     val vm: AppViewModel = viewModel()

--- a/app/src/main/java/com/iplacex/medidores_app/ui/vm/AppViewModel.kt
+++ b/app/src/main/java/com/iplacex/medidores_app/ui/vm/AppViewModel.kt
@@ -1,5 +1,7 @@
 package com.iplacex.medidores_app.ui.vm
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -35,6 +37,7 @@ data class UiState(
     val draftUnidad: String = ""
 )
 
+@RequiresApi(Build.VERSION_CODES.O)
 class AppViewModel(
     private val medidorRepository: MedidorRepository = ServiceLocator.medidorRepository,
     private val lecturaRepository: LecturaRepository = ServiceLocator.lecturaRepository
@@ -47,6 +50,7 @@ class AppViewModel(
         cargarDatosIniciales()
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun cargarDatosIniciales() {
         val medidores = medidorRepository.obtenerMedidores()
         val lecturas = lecturaRepository.obtenerLecturas()
@@ -57,6 +61,7 @@ class AppViewModel(
             draftMedidorId = medidorInicial?.id,
             draftTipo = medidorInicial?.tipo,
             draftFecha = LocalDate.now().toString(),
+            )
     }
 
     fun updateDraft(
@@ -83,6 +88,7 @@ class AppViewModel(
         )
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     fun saveDraft() {
         val medidorId = uiState.draftMedidorId ?: return
         val tipo = uiState.draftTipo ?: return
@@ -107,7 +113,6 @@ class AppViewModel(
         uiState = uiState.copy(
             lecturas = lecturasActualizadas,
             draftFecha = LocalDate.now().toString(),
-            draftFecha = "",
         )
     }
 

--- a/app/src/main/java/com/iplacex/medidores_app/ui/vm/FormScreen.kt
+++ b/app/src/main/java/com/iplacex/medidores_app/ui/vm/FormScreen.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardOptions
-import androidx.compose.ui.text.input.KeyboardType
+// import androidx.compose.ui.text.input.KeyboardOptions
+// import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.iplacex.medidores_app.domain.TipoMedidor
 import com.iplacex.medidores_app.ui.vm.UiState
@@ -21,7 +21,7 @@ fun FormScreen(
     onCancel: () -> Unit
 ) {
     Scaffold(
-        topBar = { SmallTopAppBar(title = { Text("Nueva lectura") }) }
+        topBar = { TopAppBar(title = { Text("Nueva lectura") }) }
     ) { inner ->
         Column(
             Modifier.padding(inner).padding(16.dp),
@@ -78,7 +78,7 @@ fun FormScreen(
                 value = state.draftValor,
                 onValueChange = { onValueChange(null, null, null, it) },
                 label = { Text(valorLabel) },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                //keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth()
             )

--- a/app/src/main/java/com/iplacex/medidores_app/ui/vm/ListScreen.kt
+++ b/app/src/main/java/com/iplacex/medidores_app/ui/vm/ListScreen.kt
@@ -14,13 +14,14 @@ import com.iplacex.medidores_app.ui.vm.UiLectura
 import com.iplacex.medidores_app.ui.vm.UiMedidor
 import com.iplacex.medidores_app.ui.vm.UiState
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ListScreen(
     state: UiState,
     onAddClick: () -> Unit
 ) {
     Scaffold(
-        topBar = { SmallTopAppBar(title = { Text("Lecturas") }) },
+        topBar = { TopAppBar(title = { Text("Lecturas") }) },
         floatingActionButton = {
             FloatingActionButton(onClick = onAddClick) {
                 Icon(Icons.Default.Add, contentDescription = "Agregar")


### PR DESCRIPTION
This commit introduces several changes to the UI components and ViewModel logic:

- Updated `ListScreen` and `FormScreen` to use `TopAppBar` instead of `SmallTopAppBar`.
- Added `@RequiresApi(Build.VERSION_CODES.O)` annotations to `AppNav` and several methods in `AppViewModel` due to the usage of `LocalDate.now()`.
- Removed XML declaration from `.idea/misc.xml`.
- In `AppViewModel`:
    - Ensured `draftFecha` is initialized with the current date when loading initial data.
    - Corrected an issue where `draftFecha` was being reset to an empty string after saving a draft.
- Commented out `keyboardOptions` for the valor `TextField` in `FormScreen`.