### PR TITLE
Add meter type icons to list screen

### DIFF
--- a/app/src/main/java/com/iplacex/medidores_app/ui/vm/ListScreen.kt
+++ b/app/src/main/java/com/iplacex/medidores_app/ui/vm/ListScreen.kt
@@ -1,17 +1,32 @@
 package com.iplacex.medidores_app.ui.list
 
-import androidx.compose.foundation.layout.*
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
+import androidx.compose.ui.Alignment
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.iplacex.medidores_app.R
+import com.iplacex.medidores_app.domain.TipoMedidor
 import com.iplacex.medidores_app.ui.vm.UiLectura
 import com.iplacex.medidores_app.ui.vm.UiMedidor
 import com.iplacex.medidores_app.ui.vm.UiState
@@ -50,7 +65,22 @@ private fun Lista(lecturas: List<UiLectura>, medidores: Map<String, UiMedidor>) 
             ElevatedCard(Modifier.fillMaxWidth()) {
                 Column(Modifier.padding(12.dp)) {
                     val m = medidores[l.medidorId]
-                    Text(m?.alias ?: stringResource(R.string.list_default_meter_name), fontWeight = FontWeight.SemiBold)
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        val iconRes = m?.tipo?.let { tipoIconRes(it) }
+                        if (iconRes != null) {
+                            Icon(
+                                painter = painterResource(iconRes),
+                                contentDescription = null,
+                                tint = Color.Unspecified,
+                                modifier = Modifier.size(32.dp)
+                            )
+                            Spacer(Modifier.width(12.dp))
+                        }
+                        Text(
+                            m?.alias ?: stringResource(R.string.list_default_meter_name),
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
                     Spacer(Modifier.height(4.dp))
                     val unidad = l.unidad
                     val unidadTexto = if (unidad.isBlank()) "" else " ${unidad}"
@@ -59,4 +89,11 @@ private fun Lista(lecturas: List<UiLectura>, medidores: Map<String, UiMedidor>) 
             }
         }
     }
+}
+
+@DrawableRes
+private fun tipoIconRes(tipoMedidor: TipoMedidor): Int = when (tipoMedidor) {
+    TipoMedidor.AGUA -> R.drawable.ic_agua
+    TipoMedidor.LUZ -> R.drawable.ic_luz
+    TipoMedidor.GAS -> R.drawable.ic_gas
 }

--- a/app/src/main/res/drawable/ic_agua.xml
+++ b/app/src/main/res/drawable/ic_agua.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF2196F3"
+        android:pathData="M12,2C12,2 5,11 5,16a7,7 0,0 0,14 0C19,11 12,2 12,2z" />
+</vector>

--- a/app/src/main/res/drawable/ic_gas.xml
+++ b/app/src/main/res/drawable/ic_gas.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFF5722"
+        android:pathData="M12,2C9,6.5 6,11 6,15a6,6 0,0 0,12 0c0,-4 -3,-8.5 -6,-13z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillAlpha="0.5"
+        android:pathData="M12,8c-1.5,2 -3,4.2 -3,6a3,3 0,0 0,6 0c0,-1.8 -1.5,-4 -3,-6z" />
+</vector>

--- a/app/src/main/res/drawable/ic_luz.xml
+++ b/app/src/main/res/drawable/ic_luz.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFC107"
+        android:pathData="M13,2L5,13h6l-2,9 10,-12h-6z" />
+</vector>


### PR DESCRIPTION
## Summary
- add vector drawables representing water, electricity, and gas meters
- show the corresponding icon for each reading in the list screen based on its meter type

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0270f143483228992cd44476299db